### PR TITLE
update monolog and PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "monolog/monolog": "~1.0"
+        "monolog/monolog": "~2.0"
     },
     "autoload": {
         "psr-4": {
@@ -17,7 +17,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
-        "codeclimate/php-test-reporter": "*"
+        "phpunit/phpunit": "^8.0"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
         >
     <testsuites>
         <testsuite name="monolog-ltsv-formatter Unit Tests">

--- a/test/Ltsv/LtsvLineBuilderTest.php
+++ b/test/Ltsv/LtsvLineBuilderTest.php
@@ -1,12 +1,14 @@
 <?php
 namespace Hikaeme\Monolog\Formatter\Ltsv;
 
-class LtsvLineBuilderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class LtsvLineBuilderTest extends TestCase
 {
     /** @var LtsvLineBuilder */
     private $builder;
 
-    public function setUp()
+    public function setUp():void
     {
         $this->builder = new LtsvLineBuilder(
             array("\r" => '', "\n" => '', "\t" => '', ':' => ''),

--- a/test/LtsvFormatterTest.php
+++ b/test/LtsvFormatterTest.php
@@ -2,8 +2,9 @@
 namespace Hikaeme\Monolog\Formatter;
 
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 
-class LtsvFormatterTest extends \PHPUnit_Framework_TestCase
+class LtsvFormatterTest extends TestCase
 {
     public function testFormat()
     {


### PR DESCRIPTION
For Laravel 6, monolog is updated to version 2.0, but monolog-ltsv-formatter requires 1.0.
So `composer require hikaeme/monolog-ltsv-formatter` is failed.

This PR is update monolog to 2.0.
Also update phpunit to 8.0 and modify test case to pass test.

codeclimate/php-test-reporter is removed because it requires some old package and cause too many warnings.
Instead of codeclimate/php-test-reporter, I run PHPUnit with Xdebug.